### PR TITLE
Add JVLAN preset servers

### DIFF
--- a/src/renderer/src/states/gameState.ts
+++ b/src/renderer/src/states/gameState.ts
@@ -1,5 +1,6 @@
 import axios from 'axios'
 import { create } from 'zustand'
+import { PRESET_SERVERS } from '../../../shared/presetServers'
 
 type GameStates = 'notInstalled' | 'installed' | 'running' | 'deprecated'
 
@@ -47,24 +48,39 @@ export const useGameState = create<GameState>((set) => ({
         ]
       }
     })
-    set(() => ({
-      publicServers: [
-        ...(process.env.NODE_ENV === 'development'
-          ? [
-              {
-                id: -1,
-                name: 'Localhost',
-                ip: '127.0.0.1:23600',
-                maxPlayers: 10,
-                players: 0,
-                region: 'LOCAL',
-                status: 'online'
-              }
-            ]
-          : []),
-        ...response.data
-      ]
+
+    const presetServers = PRESET_SERVERS.map((s) => ({
+      id: -1,
+      name: s.name,
+      ip: `${s.address}:${s.port}`,
+      maxPlayers: 0,
+      players: 0,
+      region: '',
+      status: 'online'
     }))
+
+    const fetchedServers = [
+      ...(process.env.NODE_ENV === 'development'
+        ? [
+            {
+              id: -1,
+              name: 'Localhost',
+              ip: '127.0.0.1:23600',
+              maxPlayers: 10,
+              players: 0,
+              region: 'LOCAL',
+              status: 'online'
+            }
+          ]
+        : []),
+      ...response.data
+    ]
+
+    const combined = [...presetServers, ...fetchedServers].filter(
+      (s, i, arr) => arr.findIndex((t) => t.ip === s.ip) === i
+    )
+
+    set(() => ({ publicServers: combined }))
   },
 
   playtime: null,

--- a/src/shared/presetServers.ts
+++ b/src/shared/presetServers.ts
@@ -1,0 +1,37 @@
+export const PRESET_SERVERS = [
+  {
+    id: 'jvlan-main',
+    name: 'JVLAN',
+    address: 'knockout.jvlan.ch',
+    port: 23600,
+    requiresAuth: false
+  },
+  {
+    id: 'jvlan-bkp1',
+    name: 'JVLAN BACKUP 1',
+    address: 'backup1-knockout.jvlan.ch',
+    port: 23600,
+    requiresAuth: false
+  },
+  {
+    id: 'jvlan-bkp2',
+    name: 'JVLAN BACKUP 2',
+    address: 'backup2-knockout.jvlan.ch',
+    port: 23600,
+    requiresAuth: false
+  },
+  {
+    id: 'jvlan-bkp3',
+    name: 'JVLAN BACKUP 3',
+    address: 'backup3-knockout.jvlan.ch',
+    port: 23600,
+    requiresAuth: false
+  },
+  {
+    id: 'jvlan-bkp4',
+    name: 'JVLAN BACKUP 4',
+    address: 'backup4-knockout.jvlan.ch',
+    port: 23600,
+    requiresAuth: false
+  }
+]

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,6 +1,6 @@
 {
   "extends": "@electron-toolkit/tsconfig/tsconfig.node.json",
-  "include": ["electron.vite.config.*", "src/main/*", "src/preload/*"],
+  "include": ["electron.vite.config.*", "src/main/*", "src/preload/*", "src/shared/**/*"],
   "compilerOptions": {
     "composite": true,
     "types": ["electron-vite/node"],

--- a/tsconfig.web.json
+++ b/tsconfig.web.json
@@ -6,6 +6,7 @@
     "src/renderer/src/**/*.html",
     "src/renderer/src/**/*.tsx",
     "src/preload/*.d.ts",
+    "src/shared/**/*"
   ],
   "compilerOptions": {
     "target": "ESNext",


### PR DESCRIPTION
## Summary
- create shared `presetServers` with JVLAN host names
- include shared folder in both tsconfigs
- combine JVLAN presets with fetched servers in `gameState`

## Testing
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6881180de2948325bff2595905ecb38e