### PR TITLE
Fix JVLAN presets missing in Private tab

### DIFF
--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,7 +1,8 @@
 import { ipcRenderer } from 'electron'
 import { getCurrentWindow } from '@electron/remote'
 import { BrowserWindow } from 'electron'
-import * as Sentry from "@sentry/electron/preload";
+import * as Sentry from '@sentry/electron/preload'
+import { PRESET_SERVERS } from '../shared/presetServers'
 const os = require('os')
 
 // Use `contextBridge` APIs to expose Electron APIs to
@@ -20,8 +21,19 @@ if (!localStorage.getItem('gameVersion')) localStorage.setItem('gameVersion', '1
 if (!localStorage.getItem('language')) localStorage.setItem('language', 'en')
 if (!localStorage.getItem('currServerName')) localStorage.setItem('currServerName', 'localhost')
 if (!localStorage.getItem('currServer')) localStorage.setItem('currServer', '127.0.0.1')
-if (localStorage.getItem('servers') === null)
-  localStorage.setItem('servers', '[{"name":"localhost","ip":"127.0.0.1"}]')
+{
+  const existing = JSON.parse(localStorage.getItem('servers') || '[]') as {
+    name: string
+    ip: string
+  }[]
+  const presetFavs = PRESET_SERVERS.map((s) => ({
+    name: s.name,
+    ip: `${s.address}:${s.port}`
+  }))
+  const combined = [...presetFavs, ...existing]
+    .filter((s, i, arr) => arr.findIndex((t) => t.ip === s.ip) === i)
+  localStorage.setItem('servers', JSON.stringify(combined))
+}
 if (!localStorage.getItem('gameDirectory'))
   localStorage.setItem(
     'gameDirectory',

--- a/src/renderer/src/states/gameState.ts
+++ b/src/renderer/src/states/gameState.ts
@@ -1,5 +1,6 @@
 import axios from 'axios'
 import { create } from 'zustand'
+import { PRESET_SERVERS } from '../../../shared/presetServers'
 
 type GameStates = 'notInstalled' | 'installed' | 'running' | 'deprecated'
 
@@ -47,24 +48,39 @@ export const useGameState = create<GameState>((set) => ({
         ]
       }
     })
-    set(() => ({
-      publicServers: [
-        ...(process.env.NODE_ENV === 'development'
-          ? [
-              {
-                id: -1,
-                name: 'Localhost',
-                ip: '127.0.0.1:23600',
-                maxPlayers: 10,
-                players: 0,
-                region: 'LOCAL',
-                status: 'online'
-              }
-            ]
-          : []),
-        ...response.data
-      ]
+
+    const presetServers = PRESET_SERVERS.map((s) => ({
+      id: -1,
+      name: s.name,
+      ip: `${s.address}:${s.port}`,
+      maxPlayers: 0,
+      players: 0,
+      region: '',
+      status: 'online'
     }))
+
+    const fetchedServers = [
+      ...(process.env.NODE_ENV === 'development'
+        ? [
+            {
+              id: -1,
+              name: 'Localhost',
+              ip: '127.0.0.1:23600',
+              maxPlayers: 10,
+              players: 0,
+              region: 'LOCAL',
+              status: 'online'
+            }
+          ]
+        : []),
+      ...response.data
+    ]
+
+    const combined = [...presetServers, ...fetchedServers].filter(
+      (s, i, arr) => arr.findIndex((t) => t.ip === s.ip) === i
+    )
+
+    set(() => ({ publicServers: combined }))
   },
 
   playtime: null,

--- a/src/shared/presetServers.ts
+++ b/src/shared/presetServers.ts
@@ -1,0 +1,37 @@
+export const PRESET_SERVERS = [
+  {
+    id: 'jvlan-main',
+    name: 'JVLAN',
+    address: 'knockout.jvlan.ch',
+    port: 23600,
+    requiresAuth: false
+  },
+  {
+    id: 'jvlan-bkp1',
+    name: 'JVLAN BACKUP 1',
+    address: 'backup1-knockout.jvlan.ch',
+    port: 23600,
+    requiresAuth: false
+  },
+  {
+    id: 'jvlan-bkp2',
+    name: 'JVLAN BACKUP 2',
+    address: 'backup2-knockout.jvlan.ch',
+    port: 23600,
+    requiresAuth: false
+  },
+  {
+    id: 'jvlan-bkp3',
+    name: 'JVLAN BACKUP 3',
+    address: 'backup3-knockout.jvlan.ch',
+    port: 23600,
+    requiresAuth: false
+  },
+  {
+    id: 'jvlan-bkp4',
+    name: 'JVLAN BACKUP 4',
+    address: 'backup4-knockout.jvlan.ch',
+    port: 23600,
+    requiresAuth: false
+  }
+]

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,6 +1,6 @@
 {
   "extends": "@electron-toolkit/tsconfig/tsconfig.node.json",
-  "include": ["electron.vite.config.*", "src/main/*", "src/preload/*"],
+  "include": ["electron.vite.config.*", "src/main/*", "src/preload/*", "src/shared/**/*"],
   "compilerOptions": {
     "composite": true,
     "types": ["electron-vite/node"],

--- a/tsconfig.web.json
+++ b/tsconfig.web.json
@@ -6,6 +6,7 @@
     "src/renderer/src/**/*.html",
     "src/renderer/src/**/*.tsx",
     "src/preload/*.d.ts",
+    "src/shared/**/*"
   ],
   "compilerOptions": {
     "target": "ESNext",


### PR DESCRIPTION
## Summary
- preload preset JVLAN servers into localStorage so they appear in favourites

## Testing
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6881180de2948325bff2595905ecb38e