### PR TITLE
Add JVLAN servers to defaults

### DIFF
--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -21,7 +21,17 @@ if (!localStorage.getItem('language')) localStorage.setItem('language', 'en')
 if (!localStorage.getItem('currServerName')) localStorage.setItem('currServerName', 'localhost')
 if (!localStorage.getItem('currServer')) localStorage.setItem('currServer', '127.0.0.1')
 if (localStorage.getItem('servers') === null)
-  localStorage.setItem('servers', '[{"name":"localhost","ip":"127.0.0.1"}]')
+  localStorage.setItem(
+    'servers',
+    JSON.stringify([
+      { name: 'localhost', ip: '127.0.0.1' },
+      { name: 'JVLAN', ip: 'knockout.jvlan.ch' },
+      { name: 'JVLAN BACKUP 1', ip: 'backup1-knockout.jvlan.ch' },
+      { name: 'JVLAN BACKUP 2', ip: 'backup2-knockout.jvlan.ch' },
+      { name: 'JVLAN BACKUP 3', ip: 'backup3-knockout.jvlan.ch' },
+      { name: 'JVLAN BACKUP 4', ip: 'backup4-knockout.jvlan.ch' }
+    ])
+  )
 if (!localStorage.getItem('gameDirectory'))
   localStorage.setItem(
     'gameDirectory',

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -20,18 +20,32 @@ if (!localStorage.getItem('gameVersion')) localStorage.setItem('gameVersion', '1
 if (!localStorage.getItem('language')) localStorage.setItem('language', 'en')
 if (!localStorage.getItem('currServerName')) localStorage.setItem('currServerName', 'localhost')
 if (!localStorage.getItem('currServer')) localStorage.setItem('currServer', '127.0.0.1')
-if (localStorage.getItem('servers') === null)
-  localStorage.setItem(
-    'servers',
-    JSON.stringify([
-      { name: 'localhost', ip: '127.0.0.1' },
-      { name: 'JVLAN', ip: 'knockout.jvlan.ch' },
-      { name: 'JVLAN BACKUP 1', ip: 'backup1-knockout.jvlan.ch' },
-      { name: 'JVLAN BACKUP 2', ip: 'backup2-knockout.jvlan.ch' },
-      { name: 'JVLAN BACKUP 3', ip: 'backup3-knockout.jvlan.ch' },
-      { name: 'JVLAN BACKUP 4', ip: 'backup4-knockout.jvlan.ch' }
-    ])
-  )
+const defaultServers = [
+  { name: 'localhost', ip: '127.0.0.1' },
+  { name: 'JVLAN', ip: 'knockout.jvlan.ch' },
+  { name: 'JVLAN BACKUP 1', ip: 'backup1-knockout.jvlan.ch' },
+  { name: 'JVLAN BACKUP 2', ip: 'backup2-knockout.jvlan.ch' },
+  { name: 'JVLAN BACKUP 3', ip: 'backup3-knockout.jvlan.ch' },
+  { name: 'JVLAN BACKUP 4', ip: 'backup4-knockout.jvlan.ch' }
+]
+
+const storedServers = localStorage.getItem('servers')
+if (storedServers === null) {
+  localStorage.setItem('servers', JSON.stringify(defaultServers))
+} else {
+  try {
+    const parsed = JSON.parse(storedServers)
+    const existingIps = new Set(parsed.map((s: { ip: string }) => s.ip))
+    const merged = [...parsed]
+    defaultServers.forEach((srv) => {
+      if (!existingIps.has(srv.ip)) merged.push(srv)
+    })
+    if (merged.length !== parsed.length)
+      localStorage.setItem('servers', JSON.stringify(merged))
+  } catch {
+    localStorage.setItem('servers', JSON.stringify(defaultServers))
+  }
+}
 if (!localStorage.getItem('gameDirectory'))
   localStorage.setItem(
     'gameDirectory',


### PR DESCRIPTION
## Summary
- include JVLAN servers as default private servers in `preload/index.ts`

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_6881373411188325be3ccc4a8044b1fd